### PR TITLE
feat: use queues for shipping new posts and updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "@anthropic-ai/sdk": "^0.29.0",
     "@aws-sdk/client-s3": "^3.670.0",
     "@aws-sdk/s3-request-presigner": "^3.670.0",
+    "@notionhq/client": "^2.2.15",
+    "notion-to-md": "^3.1.4",
+    "path": "^0.12.7",
     "replicate": "^1.0.1"
   },
   "packageManager": "yarn@4.6.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -412,7 +412,7 @@ async function commitToGitHub(
       fileChanges: {
         additions: [{
           path: filePath,
-          contents: content
+          contents: Buffer.from(content).toString('base64')
         }]
       },
       expectedHeadOid: await getLatestCommitOid(env)

--- a/src/index.ts
+++ b/src/index.ts
@@ -716,7 +716,7 @@ const processNotionWebhook = async (payload: NotionWebhookPayload, env: Env) => 
   await commitToGitHub(
     path,
     content,
-    `chore: update ${path.split('/').pop()?.split('.')[0]} from Notion`,
+    `chore: update ${path}`,
     env
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { DataRedundancy, GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import Replicate, { ApiError, validateWebhook } from 'replicate';
 import Anthropic from "@anthropic-ai/sdk";
+import { Client } from '@notionhq/client';
 
 import { Buffer } from 'node:buffer';
+import { BlockObjectResponse, ImageBlockObjectResponse, PageObjectResponse, PartialBlockObjectResponse, RichTextItemResponse, TextRichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
+import { NotionToMarkdown } from 'notion-to-md';
+import path from 'node:path';
 
 interface Env {
   CLOUDFLARE_ACCOUNT_ID: string;
@@ -18,8 +22,10 @@ interface Env {
   PORTFOLIO_BUCKET: R2Bucket;
   ANTHROPIC_API_KEY: string;
   NOTION_TOKEN: string;
+	NOTION_DATABASE_ID: string;
   GITHUB_PAT: string;
   DISPATCH_SECRET: string;
+	NOTION_QUEUE: Queue<NotionWebhookPayload>;
 }
 
 interface CachedSignedUrl {
@@ -462,6 +468,319 @@ async function getLatestCommitOid(env: Env): Promise<string> {
   return result.data.repository.defaultBranchRef.target.oid;
 }
 
+interface NotionWebhookPayload {
+  source: {
+    type: 'automation';
+    automation_id: string;
+    action_id: string;
+    event_id: string;
+    attempt: number;
+  };
+  data: {
+    object: 'page';
+    id: string;
+    created_time: string;
+    last_edited_time: string;
+    parent: {
+      type: 'database_id';
+      database_id: string;
+    };
+    properties: Record<string, any>;
+    url: string;
+    request_id: string;
+  };
+}
+
+function formatDate(dateString: string): string {
+	const date = new Date(dateString);
+	const month = date.toLocaleString('default', { month: 'short', timeZone: 'UTC' });
+	const day = date.getUTCDate().toString().padStart(2, '0');
+	const year = date.getUTCFullYear();
+	return `${month} ${day} ${year}`;
+}
+
+function formatDateForFolder(dateString: string): string {
+	return new Date(dateString).toISOString().split('T')[0];
+}
+
+type NotionClient = InstanceType<typeof Client>;
+type UpdateBlockParameters = Parameters<NotionClient['blocks']['update']>[0];
+
+function isTextRichTextItem(item: RichTextItemResponse): item is TextRichTextItemResponse {
+	return item.type === 'text';
+}
+
+function isParagraphBlock(block: BlockObjectResponse | PartialBlockObjectResponse): block is BlockObjectResponse & { type: 'paragraph' } {
+	return 'type' in block && block.type === 'paragraph';
+}
+
+import { Client } from '@notionhq/client';
+
+async function processPage(page: PageObjectResponse, env: Env) {
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  const n2m = new NotionToMarkdown({ notionClient: notion });
+
+  const mdblocks = await n2m.pageToMarkdown(page.id);
+
+  // Extract page properties
+  const title = page.properties.Title.type === 'title' && page.properties.Title.title.length > 1
+    ? page.properties.Title.title.map((t) => t.plain_text.trim()).join(' ')
+    : page.properties.Title.type === 'title'
+      ? page.properties.Title.title[0]?.plain_text.trim()
+      : 'Untitled';
+
+  const slug = page.properties.Slug.type === 'formula' && page.properties.Slug?.formula?.type == 'string'
+    ? (page.properties.Slug.formula?.string as string)
+    : '';
+
+  const description = page.properties.Description.type === 'rich_text'
+    ? page.properties.Description.rich_text[0]?.plain_text.trim()
+    : '';
+
+  // Process images in the markdown blocks
+  for (let i = 0; i < mdblocks.length; i++) {
+    const block = mdblocks[i];
+    if (block.type === 'image') {
+      const imageUrl = block.parent.match(/\((.*?)\)/)?.[1];
+      if (imageUrl) {
+        try {
+          const blockId = block.blockId || `fallback-${i}`;
+          const imageKey = `${slug}-${blockId}${new URL(imageUrl).pathname.split('.').pop()}`;
+          const { signedUrl } = await uploadImage(imageUrl, slug, blockId, env);
+          const blockObj = await notion.blocks.retrieve({ block_id: blockId }) as ImageBlockObjectResponse;
+          const caption = blockObj.image?.caption[0]?.plain_text || '';
+          mdblocks[i].parent = `<R2Image imageKey="assets/${imageKey}" alt="${caption}" />`;
+        } catch (error) {
+          console.error(`Failed to upload image: ${imageUrl}`, error);
+        }
+      }
+    }
+  }
+
+  const mdString = n2m.toMarkdownString(mdblocks);
+  const convertedMdString = mdString.parent.replace(/\[(embed|video)\]\((https?:\/\/\S+)\)/g, '$2');
+
+  // Get dates
+  const pubDate = page.properties.Date?.type === 'date' && page.properties.Date.date?.start
+    ? formatDate(page.properties.Date.date.start)
+    : formatDate(page.created_time);
+
+  const updatedDate = formatDate(page.last_edited_time);
+
+  // Get tags
+  const tags = page.properties.Tags?.type === 'multi_select'
+    ? page.properties.Tags.multi_select.map((tag) => tag.name)
+    : [];
+
+  // Get folder date
+  const folderDate = page.properties.Date?.type === 'date' && page.properties.Date.date?.start
+    ? formatDateForFolder(page.properties.Date.date.start)
+    : formatDateForFolder(page.created_time);
+
+  const postContainsImages = mdblocks.some((block) => block.parent.includes('R2Image'));
+
+  const content = `---
+title: "${title}"
+seoTitle: "${title}"
+slug: "${slug}"
+description: "${description}"
+pubDate: '${pubDate}'
+updatedDate: '${updatedDate}'
+tags: ${JSON.stringify(tags)}
+coverImage: "./image.webp"
+---
+
+${postContainsImages ? `import R2Image from 'src/components/R2Image.astro';` : ''}
+
+${convertedMdString.replace(/\n\n/g, '\n')}`;
+
+  return {
+    content,
+    path: `src/content/blog/${folderDate}-${slug}/index.mdx`
+  };
+}
+
+async function uploadImage(imageUrl: string, pageSlug: string, blockId: string): Promise<{ uploaded: boolean; signedUrl: string }> {
+	try {
+		const S3 = new S3Client({
+			region: 'auto',
+			endpoint: `https://${env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+			credentials: {
+				accessKeyId: env.CLOUDFLARE_R2_ACCESS_KEY_ID!,
+				secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY!,
+			},
+		});
+
+		// Generate a unique filename using blockId
+		const filename = `${pageSlug}-${blockId}${path.extname(imageUrl.split('?')[0])}`;
+		const key = `assets/${filename}`;
+
+		// Check if the file already exists in the bucket
+		try {
+			const headCommand = new HeadObjectCommand({
+				Bucket: env.R2_BUCKET_NAME!,
+				Key: key,
+			});
+			await S3.send(headCommand);
+
+			// If we reach here, the file exists. Generate and return a signed URL.
+			console.log('Image already exists in the bucket. Generating signed URL.');
+			const signedUrl = await getSignedUrlForObject(key);
+			return { uploaded: false, signedUrl };
+		} catch (error) {
+			// If the file doesn't exist, we'll get an error. Proceed with upload.
+			console.log('Image does not exist in the bucket. Proceeding with upload.');
+		}
+
+		// Download the image
+		const response = await fetch(imageUrl, {
+			headers: {
+				Accept: 'image/*',
+			},
+		});
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+		const buffer = await response.arrayBuffer();
+
+		// Upload to R2
+		const uploadCommand = new PutObjectCommand({
+			Bucket: env.R2_BUCKET_NAME!,
+			Key: key,
+			Body: Buffer.from(buffer),
+			ContentType: response.headers.get('content-type') || 'image/png',
+		});
+
+		const result = await S3.send(uploadCommand);
+
+		if (result.$metadata.httpStatusCode !== 200) {
+			throw new Error(`Upload failed with status code: ${result.$metadata.httpStatusCode}`);
+		}
+
+		// Generate a signed URL
+		const signedUrl = await getSignedUrlForObject(key);
+
+		console.log('Upload successful. Signed URL:', signedUrl);
+		return { uploaded: true, signedUrl };
+	} catch (error) {
+		console.error('Error uploading image to R2:', error);
+		if (error instanceof Error) {
+			console.error('Error message:', error.message);
+			console.error('Error stack:', error.stack);
+		}
+		throw error;
+	}
+}
+
+async function getSignedUrlForObject(key: string): Promise<string> {
+	const getObjectCommand = new GetObjectCommand({
+		Bucket: env.R2_BUCKET_NAME!,
+		Key: key,
+	});
+
+	return getSignedUrl(S3, getObjectCommand, { expiresIn: 3600 }); // URL expires in 1 hour
+}
+
+interface NotionWebhookPayload {
+  source: {
+    type: 'automation';
+    automation_id: string;
+    action_id: string;
+    event_id: string;
+    attempt: number;
+  };
+  data: {
+    object: 'page';
+    id: string;
+    created_time: string;
+    last_edited_time: string;
+    parent: {
+      type: 'database_id';
+      database_id: string;
+    };
+    properties: Record<string, any>;
+    url: string;
+    request_id: string;
+  };
+}
+
+// Type guard to check if a message is a Notion webhook payload
+function isNotionWebhookPayload(payload: any): payload is NotionWebhookPayload {
+  return payload
+    && 'data' in payload
+    && 'id' in payload.data
+    && 'parent' in payload.data
+    && 'database_id' in payload.data.parent;
+}
+
+// Type guard for R2 event
+function isR2Event(payload: any): payload is R2EventMessage {
+  return payload && 'action' in payload && 'object' in payload;
+}
+
+// Helper function to process Notion webhooks
+async function processNotionWebhook(payload: NotionWebhookPayload, env: Env) {
+  const pageId = payload.data.id;
+  const databaseId = payload.data.parent.database_id;
+
+  if (databaseId !== env.NOTION_DATABASE_ID) {
+    console.log('Ignoring webhook - not from target database');
+    return;
+  }
+
+  const notion = new Client({ auth: env.NOTION_TOKEN });
+  const page = await notion.pages.retrieve({ page_id: pageId });
+
+  const { content, path } = await processPage(page as PageObjectResponse, env);
+
+  await commitToGitHub(
+    path,
+    content,
+    `chore: update ${path.split('/').pop()?.split('.')[0]} from Notion`,
+    env
+  );
+
+  console.log('Successfully processed Notion webhook for page:', pageId);
+}
+
+// Helper function to process R2 events
+async function processR2Event(event: R2EventMessage, env: Env) {
+  console.log('Processing R2 event:', {
+    action: event.action,
+    sourceKey: event.copySource?.object,
+    destinationKey: event.object.key,
+    size: event.object.size,
+    eTag: event.object.eTag
+  });
+
+  const pathParts = event.object.key.split('/');
+  if (pathParts.length >= 2) {
+    const dateSlugPart = pathParts[1];
+    const r2Object = await env.PORTFOLIO_BUCKET.get(event.object.key);
+
+    if (r2Object === null) {
+      throw new Error(`Object not found in R2: ${event.object.key}`);
+    }
+
+    const arrayBuffer = await r2Object.arrayBuffer();
+    const base64Content = Buffer.from(arrayBuffer).toString('base64');
+    const imagePath = `src/content/blog/${dateSlugPart}/image.webp`;
+
+    await commitToGitHub(
+      imagePath,
+      base64Content,
+      `chore: update cover image for ${dateSlugPart}`,
+      env
+    );
+
+    console.log('Successfully processed image:', {
+      r2Path: event.object.key,
+      gitPath: imagePath,
+      size: event.object.size
+    });
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
@@ -484,72 +803,55 @@ export default {
         return handleGitHubDispatch(request, env);
       case '/webhooks/replicate':
         return handleReplicateWebhook(request, env);
+			case '/webhooks/notion':
+				// Queue the Notion webhook payload
+				const payload = await request.json() as NotionWebhookPayload;
+				await env.NOTION_QUEUE.send(payload);
+				return new Response(JSON.stringify({
+					status: 'accepted',
+					message: 'Webhook received and queued for processing'
+				}), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				});
       default:
         return new Response('Not Found', { status: 404 });
     }
   },
 	async queue(batch: MessageBatch, env: Env, ctx: ExecutionContext): Promise<void> {
-    // Process each message in the batch
     for (const message of batch.messages) {
       try {
-				const event = message.body;
+        const payload = message.body;
 
-				if (event.action === 'CopyObject' && event.object.key.endsWith('image.webp')) {
-					console.log('Processing R2 event:', {
-						action: event.action,
-						sourceKey: event.copySource?.object,
-						destinationKey: event.object.key,
-						size: event.object.size,
-						eTag: event.object.eTag
-					});
+        // Handle Notion webhook messages
+        if (isNotionWebhookPayload(payload)) {
+          await processNotionWebhook(payload, env);
+          message.ack();
+          continue;
+        }
 
-					const pathParts = event.object.key.split('/');
-					if (pathParts.length >= 2) {
-						const dateSlugPart = pathParts[1];
+        // Handle R2 events
+        if (isR2Event(payload) && payload.action === 'CopyObject' && payload.object.key.endsWith('image.webp')) {
+          await processR2Event(payload, env);
+          message.ack();
+          continue;
+        }
 
-						// Get the image from R2
-						const r2Object = await env.PORTFOLIO_BUCKET.get(event.object.key);
+        // Unknown message type
+        console.warn('Unknown message type received:', payload);
+        message.ack();
 
-						if (r2Object === null) {
-							throw new Error(`Object not found in R2: ${event.object.key}`);
-						}
-
-						// Convert the R2 object to base64
-						const arrayBuffer = await r2Object.arrayBuffer();
-						const base64Content = Buffer.from(arrayBuffer).toString('base64');
-
-						// Prepare the file path in the GitHub repo
-						const imagePath = `src/content/blog/${dateSlugPart}/image.webp`;
-
-						// Commit to GitHub
-						await commitToGitHub(
-							imagePath,
-							base64Content,
-							`chore: update cover image for ${dateSlugPart}`,
-							env
-						);
-
-						console.log('Successfully processed image:', {
-							r2Path: event.object.key,
-							gitPath: imagePath,
-							size: event.object.size
-						});
-					}
-				}
-
-				message.ack();
-			} catch (error) {
-				console.error('Error processing message:', error);
-
-				if (message.attempts < 3) {
-					message.retry({
-						delaySeconds: Math.pow(2, message.attempts) // 2s, 4s, 8s
-					});
-				} else {
-					console.error(`Failed to process message after ${message.attempts} attempts:`, message.body);
-					message.ack();
-				}
-			}
+      } catch (error) {
+        console.error('Error processing message:', error);
+        if (message.attempts < 3) {
+          message.retry({
+            delaySeconds: Math.pow(2, message.attempts) // 2s, 4s, 8s
+          });
+        } else {
+          console.error(`Failed to process message after ${message.attempts} attempts:`, message.body);
+          message.ack();
+        }
+      }
     }
   }
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -755,7 +755,7 @@ function isR2Event(payload: any): payload is R2EventMessage {
 // Helper function to process Notion webhooks
 const processNotionWebhook = async (payload: NotionWebhookPayload, request: Request, env: Env) => {
 	const s3 = createS3Client(env)
-	const processAllHeader = request.headers.get('X-Process-All-Pages');
+	const processAllHeader = request.headers.get('x-process-all-pages');
   const pageId = payload.data.id;
   const databaseId = payload.data.parent.database_id;
 
@@ -868,7 +868,7 @@ export default {
       case '/webhooks/replicate':
         return handleReplicateWebhook(request, env);
 			case '/webhooks/notion':
-				const notionSignature = request.headers.get('X-Notion-Signature');
+				const notionSignature = request.headers.get('x-notion-signature');
 				if (!notionSignature || notionSignature !== `Bearer ${env.NOTION_SIGNATURE_SECRET}`) {
 					return new Response('Unauthorized', { status: 401 });
 				}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,11 +9,13 @@ routes = [
     { pattern = "arun.blog/api/generate-image", zone_name = "arun.blog" },
     { pattern = "arun.blog/api/trigger-github-workflow", zone_name = "arun.blog" },
     { pattern = "arun.blog/webhooks/replicate*", zone_name = "arun.blog" },
+    { pattern = "arun.blog/webhooks/notion", zone_name = "arun.blog" },
     { pattern = "www.arun.blog/assets/*", zone_name = "arun.blog" },
     { pattern = "www.arun.blog/api/dispatch", zone_name = "arun.blog" },
     { pattern = "www.arun.blog/api/generate-image", zone_name = "arun.blog" },
 	{ pattern = "www.arun.blog/api/trigger-github-workflow", zone_name = "arun.blog" },
     { pattern = "www.arun.blog/webhooks/replicate*", zone_name = "arun.blog" },
+    { pattern = "www.arun.blog/webhooks/notion", zone_name = "arun.blog" },
 ]
 
 # Automatically place your workloads in an optimal location to minimize latency.
@@ -92,14 +94,19 @@ id = "b1c34589814240cfa24050edb1dd028d"
 
 # Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#queues
-# [[queues.producers]]
-# binding = "MY_QUEUE"
-# queue = "my-queue"
+[[queues.producers]]
+binding = "NOTION_QUEUE"
+queue = "notion-updates"
 
 # Bind a Queue consumer. Queue Consumers can retrieve tasks scheduled by Producers to act on them.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#queues
 [[queues.consumers]]
 queue = "cover-image-update"
+max_batch_size = 10
+max_batch_timeout = 30
+
+[[queues.consumers]]
+queue = "notion-updates"
 max_batch_size = 10
 max_batch_timeout = 30
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@notionhq/client@npm:^2.2.15":
+  version: 2.2.15
+  resolution: "@notionhq/client@npm:2.2.15"
+  dependencies:
+    "@types/node-fetch": "npm:^2.5.10"
+    node-fetch: "npm:^2.6.1"
+  checksum: 10c0/4153c2e5b47d2ba141d025f2753d0e79ca9b9f25bd8bbdfa9dbf74fe4c2e157ea7964c59387d05163972c4575830bdc48d02db29270e244d81398df0f89fd7dd
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^3.0.0":
   version: 3.0.0
   resolution: "@npmcli/agent@npm:3.0.0"
@@ -2005,6 +2015,16 @@ __metadata:
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
+  languageName: node
+  linkType: hard
+
+"@types/node-fetch@npm:^2.5.10":
+  version: 2.6.12
+  resolution: "@types/node-fetch@npm:2.6.12"
+  dependencies:
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/7693acad5499b7df2d1727d46cff092a63896dc04645f36b973dd6dd754a59a7faba76fcb777bdaa35d80625c6a9dd7257cca9c401a4bab03b04480cda7fd1af
   languageName: node
   linkType: hard
 
@@ -3021,6 +3041,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inherits@npm:2.0.3":
+  version: 2.0.3
+  resolution: "inherits@npm:2.0.3"
+  checksum: 10c0/6e56402373149ea076a434072671f9982f5fad030c7662be0332122fe6c0fa490acb3cc1010d90b6eff8d640b1167d77674add52dfd1bb85d545cf29e80e73e7
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -3177,6 +3204,15 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^12.0.0"
   checksum: 10c0/c40efb5e5296e7feb8e37155bde8eb70bc57d731b1f7d90e35a092fde403d7697c56fb49334d92d330d6f1ca29a98142036d6480a12681133a0a1453164cb2f0
+  languageName: node
+  linkType: hard
+
+"markdown-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "markdown-table@npm:2.0.0"
+  dependencies:
+    repeat-string: "npm:^1.0.0"
+  checksum: 10c0/f257e0781ea50eb946919df84bdee4ba61f983971b277a369ca7276f89740fd0e2749b9b187163a42df4c48682b71962d4007215ce3523480028f06c11ddc2e6
   languageName: node
   linkType: hard
 
@@ -3383,7 +3419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.7":
+"node-fetch@npm:2, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -3442,6 +3478,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"notion-to-md@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "notion-to-md@npm:3.1.4"
+  dependencies:
+    markdown-table: "npm:^2.0.0"
+    node-fetch: "npm:2"
+  checksum: 10c0/955ff319718a6eea3860eb196dbc06c372d4baaf0b4187f96d0c48e7d2d06b2237e4e13f8470f326a2e927d97a1857ab6593e561fd8da9e848708cb078e3f70e
+  languageName: node
+  linkType: hard
+
 "ohash@npm:^1.1.4":
   version: 1.1.4
   resolution: "ohash@npm:1.1.4"
@@ -3494,6 +3540,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path@npm:^0.12.7":
+  version: 0.12.7
+  resolution: "path@npm:0.12.7"
+  dependencies:
+    process: "npm:^0.11.1"
+    util: "npm:^0.10.3"
+  checksum: 10c0/f795ce5438a988a590c7b6dfd450ec9baa1c391a8be4c2dea48baa6e0f5b199e56cd83b8c9ebf3991b81bea58236d2c32bdafe2c17a2e70c3a2e4c69891ade59
+  languageName: node
+  linkType: hard
+
 "pathe@npm:^1.1.2":
   version: 1.1.2
   resolution: "pathe@npm:1.1.2"
@@ -3531,8 +3587,11 @@ __metadata:
     "@aws-sdk/s3-request-presigner": "npm:^3.670.0"
     "@cloudflare/vitest-pool-workers": "npm:^0.5.18"
     "@cloudflare/workers-types": "npm:^4.20250109.0"
+    "@notionhq/client": "npm:^2.2.15"
     "@vitest/runner": "npm:^2.1.8"
     "@vitest/snapshot": "npm:^2.1.8"
+    notion-to-md: "npm:^3.1.4"
+    path: "npm:^0.12.7"
     replicate: "npm:^1.0.1"
     typescript: "npm:^5.6.3"
     vitest: "npm:2.1.2"
@@ -3565,7 +3624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process@npm:^0.11.10":
+"process@npm:^0.11.1, process@npm:^0.11.10":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
   checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
@@ -3608,6 +3667,13 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.0.0":
+  version: 1.6.1
+  resolution: "repeat-string@npm:1.6.1"
+  checksum: 10c0/87fa21bfdb2fbdedc44b9a5b118b7c1239bdd2c2c1e42742ef9119b7d412a5137a1d23f1a83dc6bb686f4f27429ac6f542e3d923090b44181bafa41e8ac0174d
   languageName: node
   linkType: hard
 
@@ -4149,6 +4215,15 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/d324c5a44887bd7e105ce800fcf7533d43f29c48757ac410afd42975de82cc38ea2035c0483f4de82d186691bf3208ef35c644f73aa2b1b20b8e651be5afd293
+  languageName: node
+  linkType: hard
+
+"util@npm:^0.10.3":
+  version: 0.10.4
+  resolution: "util@npm:0.10.4"
+  dependencies:
+    inherits: "npm:2.0.3"
+  checksum: 10c0/d29f6893e406b63b088ce9924da03201df89b31490d4d011f1c07a386ea4b3dbe907464c274023c237da470258e1805d806c7e4009a5974cd6b1d474b675852a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **feat: some progress with building out a notion queue so that content changes can be pushed as webhooks rather than fetching with github workflows as is the setup now**
  

- **fix: check for X-Notion-Signature header and validate that the webhook is legit**
  

- **move notion client initialization to the processPage function**
  

- **fix: base64 encode content before committing**
  

- **fix: image upload and R2Image component (although partially because the key is incorrect)**
  

- **fix: duplicate assets keyword in the image key**
  

- **fix: commit content to reflect the updated path**
  

- **fix: commit changes only if the content differs from that on HEAD**
  

- **support committing multiple path changes at the same time**
  

- **queue all pages if the x-process-all-pages header is present, but this is not an ideal solution anyway because it spams the git tree and queues a lot of builds at vercel, I'd rather push all of them in one commit**
  

- **fix: header capitalization**
  

- **fix: when all pages update is requested, ship all changes in a single commit**
  