### PR TITLE
feat: decouple image uploads to speed up commits to source control and build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,7 @@ const getFileContent = async (path: string, env: Env): Promise<string | null> =>
 
 interface FileChange {
   path: string;
-  content: string;
+  content: string | ArrayBuffer;
 }
 
 const commitToGitHub = async (files: FileChange[], message: string, env: Env): Promise<boolean> => {
@@ -954,7 +954,7 @@ const processNotionWebhook = async (
         const imageBuffer = await getDefaultImage(env, s3);
         fileChanges.push({
           path: `${folderPath}/image.webp`,
-          content: Buffer.from(imageBuffer).toString('base64'),
+          content: imageBuffer,
         });
         console.log(`Add default index image for new page: ${folderPath}`);
       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -665,7 +665,7 @@ const processPage = async (pageId: string, env: Env, s3: S3Client) => {
           const key = `assets/${filename}`;
           mdblocks[i].parent = `<R2Image imageKey="${key}" alt="/" />`;
         } catch (error) {
-          console.error(`Failed to queue image image: ${imageUrl}`, error);
+          console.error(`Failed to queue image: ${imageUrl}`, error);
         }
       }
     }
@@ -1060,6 +1060,7 @@ export default {
             headers: { 'Content-Type': 'application/json' },
           },
         );
+      }
       default:
         return new Response('Not Found', { status: 404 });
     }
@@ -1099,7 +1100,7 @@ export default {
           console.error('Error uploading image:', error);
           if (message.attempts < 3) {
             message.retry({
-              delaySeconds: Math.pow(2, message.attempts), // 2s, 4s, 8s
+              delaySeconds: 2 ** message.attempts,
             });
           } else {
             console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1019,8 +1019,14 @@ export default {
         }
         return handleGitHubDispatch(request, env);
       case '/webhooks/replicate':
+        if (request.method !== 'POST') {
+          return new Response('Method not allowed', { status: 405 });
+        }
         return handleReplicateWebhook(request, env);
       case '/webhooks/notion': {
+        if (request.method !== 'POST') {
+          return new Response('Method not allowed', { status: 405 });
+        }
         const notionSignature =
           request.headers.get('x-notion-signature')?.replace('Bearer ', '') || '';
         if (

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -108,6 +108,15 @@ queue = "notion-updates"
 max_batch_size = 10
 max_batch_timeout = 30
 
+[[queues.producers]]
+binding = "IMAGE_UPLOAD_QUEUE"
+queue = "image-upload-queue"
+
+[[queues.consumers]]
+queue = "image-upload-queue"
+max_batch_size = 10
+max_batch_timeout = 30
+
 # Bind an R2 Bucket. Use R2 to store arbitrarily large blobs of data, such as files.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#r2-buckets
 [[r2_buckets]]


### PR DESCRIPTION
- **Handle image uploads in a queue**
  

- **Defer image processing and parallelize GitHub content checks**
  

- **chore: format codebase with biome**
  

- **chore(format): various fixes**
  

- **fix: accept only POST requests for notion and replicate webhooks**
  

- **feat: add default index image for new blog posts**
  

- **fix: commit default index image as a binary file, fixes #13**
  

- **fix: image update failure in r2 events, fixes #12**
  