### PR TITLE
fix: include timestamps in the published and updated dates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -584,7 +584,13 @@ function formatDate(dateString: string): string {
   const month = date.toLocaleString('default', { month: 'short', timeZone: 'UTC' });
   const day = date.getUTCDate().toString().padStart(2, '0');
   const year = date.getUTCFullYear();
-  return `${month} ${day} ${year}`;
+  const time = date.toLocaleString('default', { 
+    hour: 'numeric', 
+    minute: '2-digit', 
+    hour12: true, 
+    timeZone: 'UTC' 
+  });
+  return `${month} ${day} ${year} ${time}`;
 }
 
 function formatDateForFolder(dateString: string): string {


### PR DESCRIPTION
This ensures that when there are two or more blog posts published on the same date, the more recent one by time appears first. 