### PR TITLE
Fix database ID comparison by normalizing format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -968,7 +968,10 @@ const processNotionWebhook = async (
   const pageId = payload.data.id;
   const databaseId = payload.data.parent.database_id;
 
-  if (databaseId !== env.NOTION_DATABASE_ID) {
+  const normalizedDatabaseId = databaseId.replace(/[-\s]/g, '');
+  const normalizedTargetId = env.NOTION_DATABASE_ID.replace(/[-\s]/g, '');
+  
+  if (normalizedDatabaseId !== normalizedTargetId) {
     console.log('Ignoring webhook - not from target database');
     return;
   }


### PR DESCRIPTION
## Summary
- Normalize database IDs by removing hyphens and spaces before comparison
- Fixes "not from target database" webhook filtering issue when IDs have different formatting

## Test plan
- [ ] Deploy to staging and test webhook processing
- [ ] Verify webhooks from target database are processed correctly
- [ ] Confirm webhooks from other databases are still filtered out

🤖 Generated with [Claude Code](https://claude.ai/code)