### PR TITLE
fix: normalize database ID comparison in webhook handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -294,7 +294,10 @@ const handleImageGeneration = async (request: Request, env: Env) => {
     console.log('📝 Parsed payload:', { pageId, databaseId });
 
     // Validate that the request is from the correct database
-    if (databaseId !== env.NOTION_DATABASE_ID) {
+    const normalizedDatabaseId = databaseId.replace(/[-\s]/g, '');
+    const normalizedTargetId = env.NOTION_DATABASE_ID.replace(/[-\s]/g, '');
+    
+    if (normalizedDatabaseId !== normalizedTargetId) {
       console.log('❌ Invalid database ID:', { received: databaseId, expected: env.NOTION_DATABASE_ID });
       return new Response('Invalid database ID', { status: 400 });
     }


### PR DESCRIPTION
## Summary
• Fixes inconsistent database ID validation in webhook handler
• Normalizes database IDs by removing hyphens and spaces before comparison
• Ensures consistent behavior with existing normalization logic elsewhere in codebase

## Test plan
- [ ] Verify webhook validation works with database IDs containing hyphens
- [ ] Verify webhook validation works with database IDs containing spaces  
- [ ] Confirm existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)